### PR TITLE
Add presentMut lens for always replacing the current history item instead of appending

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,26 @@ thru(
 Note that modifications through `H.present` are not referentially transparent
 operations, because setting through `H.present` takes a timestamp underneath.
 
+#### <a id="H-presentReplace"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses.history/index.html#H-presentReplace) [`H.presentReplace ~> valueLens`](#H-presentReplace) <small><sup>v1.3.0</sup></small>
+
+`H.presentReplace` is a
+[lens](https://github.com/calmm-js/partial.lenses/#partial-lenses) that focuses
+on the present value of history. When read it behaves exactly as [`H.present`](#H-present). When written it does *not* create a new history entry but instead replaces the current one. This might be useful for applying multiple changes in squence without polluting the history. 
+
+For example:
+
+```js
+thru(
+  H.init({}, 42),
+  L.modify(H.presentReplace, x => -x),
+  L.get(H.undoIndex)
+)
+// 0
+```
+
+Note that modifications through `H.present` are not referentially transparent
+operations, because setting through `H.present` takes a timestamp underneath.
+
 ### <a id="undo"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses.history/index.html#undo) [Undo](#undo)
 
 #### <a id="H-undoForget"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses.history/index.html#H-undoForget) [`H.undoForget(history) ~> history`](#H-undoForget) <small><sup>v0.1.0</sup></small>

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Undo-Redo history.  Basic features:
     * [`H.init({[maxCount, pushEquals, replacePeriod]}, value) ~> history`](#H-init) <small><sup>v0.1.0</sup></small>
   * [Present](#present)
     * [`H.present ~> valueLens`](#H-present) <small><sup>v0.2.0</sup></small>
+    * [`H.presentReplace ~> valueLens`](#H-presentReplace) <small><sup>v1.3.0</sup></small>
   * [Undo](#undo)
     * [`H.undoForget(history) ~> history`](#H-undoForget) <small><sup>v0.1.0</sup></small>
     * [`H.undoIndex ~> numberLens`](#H-undoIndex) <small><sup>v0.2.0</sup></small>
@@ -302,8 +303,8 @@ thru(
 // 0
 ```
 
-Note that modifications through `H.present` are not referentially transparent
-operations, because setting through `H.present` takes a timestamp underneath.
+Note that modifications through `H.presentReplace` are not referentially transparent
+operations, because setting through `H.presentReplace` takes a timestamp underneath.
 
 ### <a id="undo"></a> [≡](#contents) [▶](https://calmm-js.github.io/partial.lenses.history/index.html#undo) [Undo](#undo)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "partial.lenses.history",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Partial Lenses History is a JavaScript library for Undo-Redo",
   "module": "dist/partial.lenses.history.es.js",
   "main": "dist/partial.lenses.history.cjs.js",

--- a/src/core.js
+++ b/src/core.js
@@ -33,7 +33,7 @@ function setPresentU(value, history) {
   )
 }
 
-function setPresentUMut(value, history) {
+function setPresentReplaceU(value, history) {
   const v = history.v
   const i = history.i
   const c = history.c
@@ -89,9 +89,9 @@ export const present = L.lens(function present(history) {
   return S.nth(history.i, history.v)
 }, setPresentU)
 
-export const presentMut = L.lens(function present(history) {
+export const presentReplace = L.lens(function presentReplace(history) {
   return S.nth(history.i, history.v)
-}, setPresentUMut)
+}, setPresentReplaceU)
 
 // Undo
 

--- a/src/core.js
+++ b/src/core.js
@@ -33,6 +33,26 @@ function setPresentU(value, history) {
   )
 }
 
+function setPresentUMut(value, history) {
+  const v = history.v
+  const i = history.i
+  const c = history.c
+  if (c.e) {
+    if (I.acyclicEqualsU(S.nth(i, v), value)) {
+      return history
+    }
+  }
+  const t = history.t
+  const now = Date.now()
+  const j0 = Math.max(0, i - c.m)
+  return construct(
+    i - j0,
+    S.append(now, S.slice(j0, i, t)),
+    S.append(value, S.slice(j0, i, v)),
+    c
+  )
+}
+
 const setIndexU = (index, history) =>
   construct(
     Math.max(0, Math.min(index, indexMax(history))),
@@ -68,6 +88,10 @@ export const indexMax = history => S.length(history.v) - 1
 export const present = L.lens(function present(history) {
   return S.nth(history.i, history.v)
 }, setPresentU)
+
+export const presentMut = L.lens(function present(history) {
+  return S.nth(history.i, history.v)
+}, setPresentUMut)
 
 // Undo
 

--- a/src/partial.lenses.history.js
+++ b/src/partial.lenses.history.js
@@ -45,7 +45,7 @@ export const init = C(
 // Present
 
 export const present = C(H.present, lens(history, V.any))
-export const presentMut = C(H.presentMut, lens(history, V.any))
+export const presentReplace = C(H.presentReplace, lens(history, V.any))
 
 // Undo
 

--- a/src/partial.lenses.history.js
+++ b/src/partial.lenses.history.js
@@ -45,6 +45,7 @@ export const init = C(
 // Present
 
 export const present = C(H.present, lens(history, V.any))
+export const presentMut = C(H.presentMut, lens(history, V.any))
 
 // Undo
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -113,6 +113,19 @@ describe('History', () => {
     )
   })
 
+  testEq([1, 2, 5, 6], async () => {
+    let h = H.init({pushEquals: true}, 1)
+    h = L.set(H.present, 2, h)
+    h = L.set(H.present, 3, h)
+    h = L.set(H.presentMut, 4, h)
+    h = L.set(H.presentMut, 5, h)
+    h = L.set(H.present, 6, h)
+    return R.map(
+      i => L.get(H.present, L.set(H.index, i, h)),
+      R.range(0, H.count(h))
+    )
+  })
+
   testEq(16000, () => {
     let h = H.init({maxCount: 5000}, 1)
     for (let i = 2; i < 20000; ++i) h = L.set(H.present, i, h)

--- a/test/tests.js
+++ b/test/tests.js
@@ -117,8 +117,8 @@ describe('History', () => {
     let h = H.init({pushEquals: true}, 1)
     h = L.set(H.present, 2, h)
     h = L.set(H.present, 3, h)
-    h = L.set(H.presentMut, 4, h)
-    h = L.set(H.presentMut, 5, h)
+    h = L.set(H.presentReplace, 4, h)
+    h = L.set(H.presentReplace, 5, h)
     h = L.set(H.present, 6, h)
     return R.map(
       i => L.get(H.present, L.set(H.index, i, h)),


### PR DESCRIPTION
Currently the latest history entry is only replaced if the modification happens inside the globally configured time window.

This PR adds a new `H.presentMut` lens that always replaces the latest history entry instead of append to the log.

This is useful for temporarily opting out of tracking changes. For example when updating a value based on the mouse position but only storing a new history value once the mouse button is released.

Not sure if is repository is still maintained but I would appreciate if this PR could be merged.